### PR TITLE
add rust-toolchain.toml that specifies nightly

### DIFF
--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
the project compiles using the rust-nightly toolchain by default